### PR TITLE
Few changes to Code Styling and Pong Class

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,16 +1,18 @@
 BasedOnStyle: LLVM
-# AlignOperands: Align
-AlignTrailingComments : Align
+AlignTrailingComments:
+  Kind: Always
+  OverEmptyLines: 2
 AccessModifierOffset: '-4'
-# AllowShortFunctionsOnASingleLine: Inline
 BreakBeforeBraces: Allman
-# BreakConstructorInitializers: AfterColon
-# ColumnLimit: '80'
+ColumnLimit: '120'
 ConstructorInitializerIndentWidth: '4'
 ContinuationIndentWidth: '4'
 IndentWidth: '4'
+MaxEmptyLinesToKeep: 3
+# AlignOperands: Align
+# AllowShortFunctionsOnASingleLine: Inline
+# BreakConstructorInitializers: AfterColon
 # Language: Cpp
-# MaxEmptyLinesToKeep: 3
 # NamespaceIndentation: All
 # PenaltyBreakAssignment: 21
 # PenaltyBreakBeforeFirstCallParameter: '0'

--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,6 @@
 BasedOnStyle: LLVM
 # AlignOperands: Align
+AlignTrailingComments : Align
 AccessModifierOffset: '-4'
 # AllowShortFunctionsOnASingleLine: Inline
 BreakBeforeBraces: Allman

--- a/src/pong.cpp
+++ b/src/pong.cpp
@@ -1,16 +1,18 @@
 #include "pong.hpp"
 #include <SFML/Graphics/Rect.hpp>
+#include <SFML/System/Clock.hpp>
 #include <SFML/System/Vector2.hpp>
+#include <SFML/Window/Event.hpp>
 #include <SFML/Window/VideoMode.hpp>
+#include <iostream>
 
 const sf::Vector2i DEFAULT_WIN_DIMS{1366, 768};
 const int DEFAULT_FRAME_LIMIT = 120;
 
 Pong::Pong()
-    : m_window(sf::VideoMode(DEFAULT_WIN_DIMS.x, DEFAULT_WIN_DIMS.y),
-               "Pong Game"),
-      m_camera(static_cast<sf::Vector2f>(DEFAULT_WIN_DIMS / 2),
-               static_cast<sf::Vector2f>(DEFAULT_WIN_DIMS))
+    : m_window(sf::VideoMode(DEFAULT_WIN_DIMS.x, DEFAULT_WIN_DIMS.y), "Pong Game"),
+      m_camera(static_cast<sf::Vector2f>(DEFAULT_WIN_DIMS / 2), static_cast<sf::Vector2f>(DEFAULT_WIN_DIMS)),
+      m_clock(sf::Clock()), m_previous_time(), m_dt(0.0f)
 {
     m_window.setFramerateLimit(DEFAULT_FRAME_LIMIT);
 }
@@ -20,41 +22,57 @@ void Pong::run()
 {
     while (m_window.isOpen())
     {
+        // Updates m_dt for use in physics / rendering purposes.
+        // Must be called first
+        updateDeltaTime();
+
         // Check for any inputs (polling events)
         sf::Event event;
-        handleEvents(event);
+        while (m_window.pollEvent(event))
+        {
+            handleCommonEvents(event);
+            // TODO: add StateManager->handleStateSpecificEvents();
+        }
 
-        // Update logic of the program
-        updateGameLogic();
+        // Update logic of the program.
+        updateCommonLogic(m_dt);
+        // TODO: add StateManager->updateStateSpecificLogic(m_dt);
 
         // Rendering
         m_window.clear();
 
         // draw() Commands Here:
+        // TODO: add StateManager->drawStateSpecificItems();
 
         // Display the whatever you have drawn after m_window.clear();
         m_window.display();
     }
 }
 
-void Pong::updateGameLogic() {}
-
-void Pong::handleEvents(sf::Event &event)
+void Pong::updateDeltaTime()
 {
-    // We put this in a while loop to ensure that the events are polled
-    while (m_window.pollEvent(event))
+    sf::Time current_time = m_clock.getElapsedTime();
+    m_dt = (current_time - m_previous_time).asSeconds();
+    m_previous_time = current_time;
+}
+
+void Pong::updateCommonLogic(const float &dt){};
+
+
+
+void Pong::handleCommonEvents(const sf::Event &event)
+{
+
+    if (event.type == sf::Event::Closed)
     {
-        if (event.type == sf::Event::Closed)
+        m_window.close();
+    }
+
+    if (event.type == sf::Event::KeyPressed)
+    {
+        if (event.key.code == sf::Keyboard::Escape)
         {
             m_window.close();
-        }
-
-        if (event.type == sf::Event::KeyPressed)
-        {
-            if (event.key.code == sf::Keyboard::Escape)
-            {
-                m_window.close();
-            }
         }
     }
 }

--- a/src/pong.hpp
+++ b/src/pong.hpp
@@ -13,41 +13,71 @@
  *
  */
 
-/**                     Naming Scheme:
+/*                      Naming Scheme:
+ *
+ * <---------------        private variables        --------------->
+ * names start with m_ :           int m_number;
+ * names are spaced by m_ :        int m_long_number;
+ *
+ * <---------------         public variables        --------------->
+ * names start with _ :            int _number;
+ * names are spaced by _ :         int _long_number;
+ *
+ * <---------------             methods             --------------->
+ * names follow camelCase:         void doThisAndThat();
+ * name
+ */
 
-<---------------        private variables        --------------->
-names start with m_ :           int m_number;
-names are spaced by m_ :        int m_long_number;
 
-<---------------         public variables        --------------->
-names start with _ :            int _number;
-names are spaced by _ :         int _long_number;
+/*
+ * Below are the different states for the game.
+ * Note that a states here refers to a different sections of the program:
+ * E.G. when you are completely switching over to drawing a different thing,
+ * and running a different part of the code.
+ */
+//* Game State Explanations
+//* MENU_MAIN,     Select between Singleplayer, Multiplayer, Options Menu, or Quit
+//* MENU_OPTIONS,  Customize some shit I guess?
+//* MENU_CONNECT,  Menu that have HOST and JOIN as options.
+//* MENU_HOST,     Menu to wait for hosts to wait for incoming connections.
+//* MENU_JOIN,     Menu to input ip and shit to connect to a host's game.
+//* GAME_RUNNING,  Run game. Game should have a single / multiplayer toggle. Upon game over prompt restart menu.
+//* GAME_PAUSED    Overlay menu which pauses the game. Give option to quit.
 
-<---------------             methods             --------------->
-names follow camelCase:         void doThisAndThat();
-name
-*/
 
+
+// TODO: Add a StateManager class into Pong, Pong::run() method should call the StateManager::handleEvents
 class Pong
 {
 private:
     sf::RenderWindow m_window;
     sf::View m_camera;
+    sf::Clock m_clock;
+    sf::Time m_previous_time;
+    // Time Step Between Frames in seconds
+    float m_dt;
 
 public:
     Pong();
     ~Pong();
     /**
      * Runs the game, should only be called once.
+     * Contains the game loop.
      */
     void run();
 
 private:
-    void updateGameLogic();
+    void updateDeltaTime();
     /**
-     * Processes window events and inputs
+     * Updates the common logic based on the current state of the game.
      */
-    void handleEvents(sf::Event &event);
+    void updateCommonLogic(const float &dt);
+    /**
+     * Processes individual events and inputs AFTER it is polled.
+     * This needs to be inside the while(pollevents()) loop.
+     * Events handled here should contain only common events regardless of gamestate.
+     */
+    void handleCommonEvents(const sf::Event &event);
 };
 
 #endif // WINDOW_HPP


### PR DESCRIPTION
# Changes:

## Code Style updated to align consecutive comments

## Renamed a few methods in the Pong Class
```Pong::updateGameLogic -> Pong::updateCommmonLogic
 Pong::handleEvents -> Pong::handleCommonEvents
```
##  Moved `pollevents()` out of `Pong::handleCommonEvents()`
`while(pollevents())` consumes all the buffered evens that happens in the run loop. Subsequent calls to `pollevents()` will not return any events. To ensure that the game's code can be neatly organized into different State Classes in the future, we will have to call both the StateManager's `handleStateEvents`  and the common `Pong::handleCommonEvents()` while inside `Pong::run()`'s `while(pollevents())` loop.

## Added TODOs to implement StateManager stuff.

## Added a comment in `pong.hpp` to briefly describe the different game states.
