### PR TITLE
Implemented StateInterface and StateManager Classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,13 @@ add_compile_options(
 set(SOURCEFILES
 src/main.cpp
 src/pong.cpp
+src/state_manager.cpp
 )
 
 set(HEADERFILES
+src/state_interface.hpp
 src/pong.hpp
+src/state_manager.hpp
 )
 
 add_executable(${PROJECTNAME} ${SOURCEFILES})

--- a/src/pong.cpp
+++ b/src/pong.cpp
@@ -5,6 +5,8 @@
 #include <SFML/Window/Event.hpp>
 #include <SFML/Window/VideoMode.hpp>
 #include <iostream>
+#include <memory>
+
 
 const sf::Vector2i DEFAULT_WIN_DIMS{1366, 768};
 const int DEFAULT_FRAME_LIMIT = 120;
@@ -15,6 +17,11 @@ Pong::Pong()
       m_clock(sf::Clock()), m_previous_time(), m_dt(0.0f)
 {
     m_window.setFramerateLimit(DEFAULT_FRAME_LIMIT);
+
+    //*Note: std::make_unique<ExampleState>(blahblah) is equivalent to doing new ExampleState(blahblah)
+    //* Use the following to initialize the first state of the game.
+    // TODO Put this into it's own init() function
+    //* m_state_manager.pushState(std::make_unique<ExampleState>(this));
 }
 Pong::~Pong() {}
 
@@ -31,23 +38,25 @@ void Pong::run()
         while (m_window.pollEvent(event))
         {
             handleCommonEvents(event);
-            // TODO: add StateManager->handleStateSpecificEvents();
+            m_state_manager.handleStateEvents(event);
         }
 
         // Update logic of the program.
         updateCommonLogic(m_dt);
-        // TODO: add StateManager->updateStateSpecificLogic(m_dt);
+        m_state_manager.updateStateLogic(m_dt);
 
         // Rendering
         m_window.clear();
 
-        // draw() Commands Here:
-        // TODO: add StateManager->drawStateSpecificItems();
+        drawCommonElements();
+        m_state_manager.drawStateElements();
 
         // Display the whatever you have drawn after m_window.clear();
         m_window.display();
     }
 }
+
+sf::RenderWindow &Pong::getWindow() { return m_window; }
 
 void Pong::updateDeltaTime()
 {
@@ -75,4 +84,9 @@ void Pong::handleCommonEvents(const sf::Event &event)
             m_window.close();
         }
     }
+}
+
+void Pong::drawCommonElements()
+{
+    // draw() Commands Here:
 }

--- a/src/pong.cpp
+++ b/src/pong.cpp
@@ -27,6 +27,8 @@ Pong::~Pong() {}
 
 void Pong::run()
 {
+    //? Perhaps Common Events and Elements should be handled last?
+    //? Common elements may need to be rendered above state elements...
     while (m_window.isOpen())
     {
         // Updates m_dt for use in physics / rendering purposes.

--- a/src/pong.cpp
+++ b/src/pong.cpp
@@ -1,16 +1,18 @@
 #include "pong.hpp"
 #include <SFML/Graphics/Rect.hpp>
+#include <SFML/System/Clock.hpp>
 #include <SFML/System/Vector2.hpp>
+#include <SFML/Window/Event.hpp>
 #include <SFML/Window/VideoMode.hpp>
+#include <iostream>
 
 const sf::Vector2i DEFAULT_WIN_DIMS{1366, 768};
 const int DEFAULT_FRAME_LIMIT = 120;
 
 Pong::Pong()
-    : m_window(sf::VideoMode(DEFAULT_WIN_DIMS.x, DEFAULT_WIN_DIMS.y),
-               "Pong Game"),
-      m_camera(static_cast<sf::Vector2f>(DEFAULT_WIN_DIMS / 2),
-               static_cast<sf::Vector2f>(DEFAULT_WIN_DIMS))
+    : m_window(sf::VideoMode(DEFAULT_WIN_DIMS.x, DEFAULT_WIN_DIMS.y), "Pong Game"),
+      m_camera(static_cast<sf::Vector2f>(DEFAULT_WIN_DIMS / 2), static_cast<sf::Vector2f>(DEFAULT_WIN_DIMS)),
+      m_clock(sf::Clock()), m_previous_time(), m_dt(0.0f)
 {
     m_window.setFramerateLimit(DEFAULT_FRAME_LIMIT);
 }
@@ -20,41 +22,57 @@ void Pong::run()
 {
     while (m_window.isOpen())
     {
+        // Updates m_dt for use in physics / rendering purposes.
+        // Must be called first
+        updateDeltaTime();
+
         // Check for any inputs (polling events)
         sf::Event event;
-        handleEvents(event);
+        while (m_window.pollEvent(event))
+        {
+            handleCommonEvents(event);
+            // TODO: add StateManager->handleStateSpecificEvents();
+        }
 
-        // Update logic of the program
-        updateGameLogic();
+        // Update logic of the program.
+        updateCommonLogic(m_dt);
+        // TODO: add StateManager->updateStateSpecificLogic(m_dt);
 
         // Rendering
         m_window.clear();
 
         // draw() Commands Here:
+        // TODO: add StateManager->drawStateSpecificItems();
 
         // Display the whatever you have drawn after m_window.clear();
         m_window.display();
     }
 }
 
-void Pong::updateGameLogic() {}
-
-void Pong::handleEvents(sf::Event &event)
+void Pong::updateDeltaTime()
 {
-    // We put this in a while loop to ensure that the events are polled
-    while (m_window.pollEvent(event))
+    sf::Time current_time = m_clock.getElapsedTime();
+    m_dt = (current_time - m_previous_time).asSeconds();
+    m_previous_time = current_time;
+}
+
+void Pong::updateCommonLogic(const float &dt){};
+
+
+
+void Pong::handleCommonEvents(const sf::Event &event)
+{
+
+    if (event.type == sf::Event::Closed)
     {
-        if (event.type == sf::Event::Closed)
+        m_window.close();
+    }
+
+    if (event.type == sf::Event::KeyPressed)
+    {
+        if (event.key.code == sf::Keyboard::Escape)
         {
             m_window.close();
-        }
-
-        if (event.type == sf::Event::KeyPressed)
-        {
-            if (event.key.code == sf::Keyboard::Escape)
-            {
-                m_window.close();
-            }
         }
     }
 }

--- a/src/pong.hpp
+++ b/src/pong.hpp
@@ -1,7 +1,9 @@
 #ifndef WINDOW_HPP
 #define WINDOW_HPP
+#include "state_manager.hpp"
 #include <SFML/Graphics.hpp>
 #include <SFML/Graphics/RenderWindow.hpp>
+
 
 /**
  * @file pong.hpp
@@ -54,6 +56,7 @@ private:
     sf::View m_camera;
     sf::Clock m_clock;
     sf::Time m_previous_time;
+    StateManager m_state_manager;
     // Time Step Between Frames in seconds
     float m_dt;
 
@@ -65,6 +68,7 @@ public:
      * Contains the game loop.
      */
     void run();
+    sf::RenderWindow &getWindow();
 
 private:
     void updateDeltaTime();
@@ -78,6 +82,8 @@ private:
      * Events handled here should contain only common events regardless of gamestate.
      */
     void handleCommonEvents(const sf::Event &event);
+
+    void drawCommonElements();
 };
 
 #endif // WINDOW_HPP

--- a/src/pong.hpp
+++ b/src/pong.hpp
@@ -13,41 +13,71 @@
  *
  */
 
-/**                     Naming Scheme:
+/*                      Naming Scheme:
+ *
+ * <---------------        private variables        --------------->
+ * names start with m_ :           int m_number;
+ * names are spaced by m_ :        int m_long_number;
+ *
+ * <---------------         public variables        --------------->
+ * names start with _ :            int _number;
+ * names are spaced by _ :         int _long_number;
+ *
+ * <---------------             methods             --------------->
+ * names follow camelCase:         void doThisAndThat();
+ * name
+ */
 
-<---------------        private variables        --------------->
-names start with m_ :           int m_number;
-names are spaced by m_ :        int m_long_number;
 
-<---------------         public variables        --------------->
-names start with _ :            int _number;
-names are spaced by _ :         int _long_number;
+/*
+ * Below are the different states for the game.
+ * Note that a states here refers to a different sections of the program:
+ * E.G. when you are completely switching over to drawing a different thing,
+ * and running a different part of the code.
+ */
+//* Game State Explanations
+//* MENU_MAIN,     Select between Singleplayer, Multiplayer, Options Menu, or Quit
+//* MENU_OPTIONS,  Customize some shit I guess?
+//* MENU_CONNECT,  Menu that have HOST and JOIN as options.
+//* MENU_HOST,     Menu to wait for hosts to wait for incoming connections.
+//* MENU_JOIN,     Menu to input ip and shit to connect to a host's game.
+//* GAME_RUNNING,  Run game. Game should have a single / multiplayer toggle. Upon game over prompt restart menu.
+//* GAME_PAUSED    Overlay menu which pauses the game. Give option to quit.
 
-<---------------             methods             --------------->
-names follow camelCase:         void doThisAndThat();
-name
-*/
 
+
+// TODO: Add a StateManager class into Pong, Pong::run() method should call the StateManager::handleEvents
 class Pong
 {
 private:
     sf::RenderWindow m_window;
     sf::View m_camera;
+    sf::Clock m_clock;
+    sf::Time m_previous_time;
+    // Time Step Between Frames in seconds
+    float m_dt;
 
 public:
     Pong();
     ~Pong();
     /**
      * Runs the game, should only be called once.
+     * Contains the game loop.
      */
     void run();
 
 private:
-    void updateGameLogic();
+    void updateDeltaTime();
     /**
-     * Processes window events and inputs
+     * Updates the common logic based on the current state of the game.
      */
-    void handleEvents(sf::Event &event);
+    void updateCommonLogic(const float &dt);
+    /**
+     * Processes individual events and inputs AFTER it is polled.
+     * This needs to be inside the while(pollevents()) loop.
+     * Events handled here should contain only common events regardless of gamestate.
+     */
+    void handleCommonEvents(const sf::Event &event);
 };
 
 #endif // WINDOW_HPP

--- a/src/state_interface.hpp
+++ b/src/state_interface.hpp
@@ -1,0 +1,22 @@
+#ifndef STATE_HPP
+#define STATE_HPP
+#include <SFML/Window/Event.hpp>
+
+class Pong;
+
+class StateInterface
+{
+protected:
+    // Pointer to acccess app's memory
+    Pong *m_program_ptr;
+
+public:
+    virtual ~StateInterface(){};
+
+
+    virtual void handleEvents(sf::Event &event) = 0;
+    virtual void updateLogic(const float &dt) = 0;
+    virtual void drawElements() = 0;
+};
+
+#endif // STATE_HPP

--- a/src/state_manager.cpp
+++ b/src/state_manager.cpp
@@ -1,0 +1,78 @@
+#include "state_manager.hpp"
+#include <iostream>
+
+StateManager::StateManager() : m_add(false), m_replace(false), m_remove(false) {}
+
+StateManager::~StateManager() {}
+
+void StateManager::pushState(std::unique_ptr<StateInterface> newstate) { m_stack.push(std::move(newstate)); }
+
+void StateManager::popState() { m_stack.pop(); }
+
+void StateManager::changeState(std::unique_ptr<StateInterface> newstate)
+{
+    m_stack.pop();
+    m_stack.push(std::move(newstate));
+}
+
+void StateManager::processStateChange()
+{
+    if (m_remove && (!m_stack.empty()))
+    {
+        m_stack.pop();
+        //? Maybe we should add an explicit start running State code here?
+        m_remove = false;
+    }
+
+    if (m_add)
+    {
+        if (m_replace && (!m_stack.empty()))
+        {
+            m_stack.pop();
+            m_replace = false;
+        }
+
+        //? Likewise, should we add an explicit call to pause the previous state code?
+
+        m_stack.push(std::move(m_new_state));
+        //? Perhaps also add a way to init states?
+        //? and start here too perhaps?
+        m_add = false;
+    }
+}
+
+void StateManager::handleStateEvents(sf::Event &event)
+{
+    if (!m_stack.empty())
+    {
+        m_stack.top()->handleEvents(event);
+    }
+    else
+    {
+        std::cerr << "WARNING: NO STATES ARE PRESENT IN THE STATE MANAGER, CALL TO handleStateEvents() SKIPPED.\n";
+    }
+}
+
+void StateManager::updateStateLogic(const float &dt)
+{
+    if (!m_stack.empty())
+    {
+        m_stack.top()->updateLogic(dt);
+    }
+    else
+    {
+        std::cerr << "WARNING: NO STATES ARE PRESENT IN THE STATE MANAGER, CALL TO updateStateLogic() SKIPPED.\n";
+    }
+}
+
+void StateManager::drawStateElements()
+{
+    if (!m_stack.empty())
+    {
+        m_stack.top()->drawElements();
+    }
+    else
+    {
+        std::cerr << "WARNING: NO STATES ARE PRESENT IN THE STATE MANAGER, CALL TO drawStateElements() SKIPPED.\n";
+    }
+}

--- a/src/state_manager.cpp
+++ b/src/state_manager.cpp
@@ -4,7 +4,7 @@
 StateManager::StateManager() : m_add(false), m_replace(false), m_remove(false) {}
 
 StateManager::~StateManager() {}
-
+// TODO: prevent pushState,popState,changeState from modifiying current state. It should be through processStateChange
 void StateManager::pushState(std::unique_ptr<StateInterface> newstate) { m_stack.push(std::move(newstate)); }
 
 void StateManager::popState() { m_stack.pop(); }

--- a/src/state_manager.hpp
+++ b/src/state_manager.hpp
@@ -1,0 +1,48 @@
+#ifndef STATEMANAGER_HPP
+#define STATEMANAGER_HPP
+#include "state_interface.hpp"
+#include <memory>
+#include <stack>
+
+
+class StateManager
+{
+private:
+    std::stack<std::unique_ptr<StateInterface>> m_stack;
+    bool m_add;
+    bool m_replace;
+    bool m_remove;
+    std::unique_ptr<StateInterface> m_new_state;
+
+public:
+    StateManager();
+    ~StateManager();
+
+    /**
+     * Adds a new state without removing the previous one.
+     * Use if you want to preserve the data of the previous state.
+     * Note that operations only proceed after `processStateChanges()` is called.
+     */
+    void pushState(std::unique_ptr<StateInterface> newstate);
+    /**
+     * Removes the current state, returning to the previous one.
+     * Note that the removed state will have it's data wiped
+     * Note that operations only proceed after `processStateChanges()` is called.
+     */
+    void popState();
+    /**
+     * Changes the current state to a different one.
+     * Note that the data in the current state will be wiped.
+     * Equivalent to calling `popState(); pushState(newState);`
+     * Note that operations only proceed after `processStateChanges()` is called.
+     */
+    void changeState(std::unique_ptr<StateInterface> newstate);
+
+    void processStateChange();
+
+    void handleStateEvents(sf::Event &event);
+    void updateStateLogic(const float &dt);
+    void drawStateElements();
+};
+
+#endif // STATEMANAGER_HPP


### PR DESCRIPTION
# `StateInterface` Class
This class should be the base class for all derived state classes.
To create a derived class from it, you have to override the following 3 pure virtual functions:
```
virtual void handleEvents(sf::Event &event) = 0;
virtual void updateLogic(const float &dt) = 0;
virtual void drawElements() = 0;
```
**It is crucial to ensure that your derived class constructor initializes `Pong *m_program_ptr`, the pointer to the Pong App class.**
Also the Pong class is currently a bit of a misnomer, might need to rename to something like `Program` / `App` soon.

# `StateManager` Class
This class handles states transitions, and dispatches the appropriate state dependent methods for `Pong` to use in the program loop.
Currently state changes apply immediately upon execution which may lead to unexpected bugs. In a future commit, `processStateChange()` needs to be called before applying changes.

